### PR TITLE
Implement positional-only arguments

### DIFF
--- a/Documentation/Unimplemented builtins.txt
+++ b/Documentation/Unimplemented builtins.txt
@@ -61,6 +61,8 @@ code
     co_names
     co_stacksize
     co_varnames
+  This should not be here:
+    co_posonlyargcount
 
 complex
   Missing:

--- a/Elsa definitions/ast.letitgo
+++ b/Elsa definitions/ast.letitgo
@@ -721,6 +721,8 @@ https://greentreesnakes.readthedocs.io/en/latest/nodes.html
   -- When a function is called, positional arguments are mapped
   -- to these parameters based solely on their position.
   Argument* args,
+  -- Count of positional-only arguments.
+  Int posOnlyArgCount,
   -- Default values for positional arguments.
   -- If there are fewer defaults, they correspond to the last *n* arguments.
   -- - Important: The default value is evaluated only **once**.

--- a/PyTests/RustPython/function_args.py
+++ b/PyTests/RustPython/function_args.py
@@ -115,18 +115,17 @@ with assert_raises(TypeError):
     f(**x, **y)
 
 
-# VIOLET: This is not a valid Python code!
-# def f(a, b, /, c, d, *, e, f):
-#     return a + b + c + d + e + f
+def f(a, b, /, c, d, *, e, f):
+    return a + b + c + d + e + f
 
-# assert f(1,2,3,4,e=5,f=6) == 21
-# assert f(1,2,3,d=4,e=5,f=6) == 21
-# assert f(1,2,c=3,d=4,e=5,f=6) == 21
-# with assert_raises(TypeError):
-#     f(1,b=2,c=3,d=4,e=5,f=6)
-# with assert_raises(TypeError):
-#     f(a=1,b=2,c=3,d=4,e=5,f=6)
-# with assert_raises(TypeError):
-#     f(1,2,3,4,5,f=6)
-# with assert_raises(TypeError):
-#     f(1,2,3,4,5,6)
+assert f(1,2,3,4,e=5,f=6) == 21
+assert f(1,2,3,d=4,e=5,f=6) == 21
+assert f(1,2,c=3,d=4,e=5,f=6) == 21
+with assert_raises(TypeError):
+    f(1,b=2,c=3,d=4,e=5,f=6)
+with assert_raises(TypeError):
+    f(a=1,b=2,c=3,d=4,e=5,f=6)
+with assert_raises(TypeError):
+    f(1,2,3,4,5,f=6)
+with assert_raises(TypeError):
+    f(1,2,3,4,5,6)

--- a/Sources/Bytecode/Builder/CodeObjectBuilder.swift
+++ b/Sources/Bytecode/Builder/CodeObjectBuilder.swift
@@ -14,6 +14,7 @@ public final class CodeObjectBuilder {
   public let freeVariableNames: [MangledName]
   public let cellVariableNames: [MangledName]
   public let argCount: Int
+  public let posOnlyArgCount: Int
   public let kwOnlyArgCount: Int
   public let firstLine: SourceLine
 
@@ -38,6 +39,7 @@ public final class CodeObjectBuilder {
               freeVariableNames: [MangledName],
               cellVariableNames: [MangledName],
               argCount: Int,
+              posOnlyArgCount: Int,
               kwOnlyArgCount: Int,
               firstLine: SourceLine) {
     self.name = name
@@ -49,6 +51,7 @@ public final class CodeObjectBuilder {
     self.freeVariableNames = freeVariableNames
     self.cellVariableNames = cellVariableNames
     self.argCount = argCount
+    self.posOnlyArgCount = posOnlyArgCount
     self.kwOnlyArgCount = kwOnlyArgCount
     self.firstLine = firstLine
 
@@ -110,6 +113,7 @@ public final class CodeObjectBuilder {
                       freeVariableNames: self.freeVariableNames,
                       cellVariableNames: self.cellVariableNames,
                       argCount: self.argCount,
+                      posOnlyArgCount: self.posOnlyArgCount,
                       kwOnlyArgCount: self.kwOnlyArgCount)
   }
 

--- a/Sources/Bytecode/CodeObject+CustomStringConvertible.swift
+++ b/Sources/Bytecode/CodeObject+CustomStringConvertible.swift
@@ -11,6 +11,7 @@ extension CodeObject: CustomStringConvertible {
       Kind: \(self.kind)
       Flags: \(self.flags)
       Arg count: \(self.argCount)
+      Positional only arg count: \(self.posOnlyArgCount)
       Keyword only arg count: \(self.kwOnlyArgCount)
       First line: \(self.firstLine)
 

--- a/Sources/Bytecode/CodeObject.swift
+++ b/Sources/Bytecode/CodeObject.swift
@@ -269,7 +269,7 @@ public final class CodeObject: Equatable {
   /// - keyword argument name (i.e., **kwargs)
   /// - any other local variable names.
   ///
-  /// So you need to look at `argCount`, `kwOnlyArgCount` and `codeFlags`
+  /// So you need to look at `argCount`, `posOnlyArgCount`, `kwOnlyArgCount` and `codeFlags`
   /// to fully interpret this
   ///
   /// This value is taken directly from the SymbolTable.
@@ -300,6 +300,9 @@ public final class CodeObject: Equatable {
   /// Argument count (excluding `*args`).
   /// CPython: `co_argcount`.
   public let argCount: Int
+  /// Positional only argument count.
+  /// CPython: `co_posonlyargcount`.
+  public let posOnlyArgCount: Int
   /// Keyword only argument count.
   /// CPython: `co_kwonlyargcount`.
   public let kwOnlyArgCount: Int
@@ -321,6 +324,7 @@ public final class CodeObject: Equatable {
                 freeVariableNames: [MangledName],
                 cellVariableNames: [MangledName],
                 argCount: Int,
+                posOnlyArgCount: Int,
                 kwOnlyArgCount: Int) {
     self.name = name
     self.qualifiedName = qualifiedName
@@ -337,6 +341,7 @@ public final class CodeObject: Equatable {
     self.freeVariableNames = freeVariableNames
     self.cellVariableNames = cellVariableNames
     self.argCount = argCount
+    self.posOnlyArgCount = posOnlyArgCount
     self.kwOnlyArgCount = kwOnlyArgCount
   }
 

--- a/Sources/Compiler/Implementation/CompilerImpl+Function.swift
+++ b/Sources/Compiler/Implementation/CompilerImpl+Function.swift
@@ -21,10 +21,12 @@ extension CompilerImpl {
                                    location: location)
 
     let argCount = node.args.args.count
+    let posOnlyArgCount = node.args.posOnlyArgCount
     let kwOnlyArgCount = node.args.kwOnlyArgs.count
 
     let codeObject = try self.inNewCodeObject(node: node,
                                               argCount: argCount,
+                                              posOnlyArgCount: posOnlyArgCount,
                                               kwOnlyArgCount: kwOnlyArgCount) {
       assert(self.builder.kind == .lambda)
 
@@ -57,10 +59,12 @@ extension CompilerImpl {
                               location: location)
 
     let argCount = node.args.args.count
+    let posOnlyArgCount = node.args.posOnlyArgCount
     let kwOnlyArgCount = node.args.kwOnlyArgs.count
 
     let codeObject = try self.inNewCodeObject(node: node,
                                               argCount: argCount,
+                                              posOnlyArgCount: posOnlyArgCount,
                                               kwOnlyArgCount: kwOnlyArgCount) {
       assert(self.builder.kind == .function)
       try self.visitBody(body: node.body, onDoc: .appendToConstants)

--- a/Sources/Compiler/Implementation/CompilerImpl+InNewCodeObject.swift
+++ b/Sources/Compiler/Implementation/CompilerImpl+InNewCodeObject.swift
@@ -21,6 +21,7 @@ extension CompilerImpl {
   ) rethrows -> CodeObject {
     return try self.inNewCodeObject(node: node,
                                     argCount: 0,
+                                    posOnlyArgCount: 0,
                                     kwOnlyArgCount: 0,
                                     emitInstructions: block)
   }
@@ -33,11 +34,13 @@ extension CompilerImpl {
   internal func inNewCodeObject<N: ASTNode>(
     node: N,
     argCount: Int,
+    posOnlyArgCount: Int,
     kwOnlyArgCount: Int,
     emitInstructions block: () throws -> Void
   ) rethrows -> CodeObject {
     self.enterScope(node: node,
                     argCount: argCount,
+                    posOnlyArgCount: posOnlyArgCount,
                     kwOnlyArgCount: kwOnlyArgCount)
 
     try block()
@@ -54,6 +57,7 @@ extension CompilerImpl {
   /// compiler_enter_scope(struct compiler *c, identifier name, ...)
   private func enterScope<N: ASTNode>(node: N,
                                       argCount: Int,
+                                      posOnlyArgCount: Int,
                                       kwOnlyArgCount: Int) {
 
     guard let scope = self.symbolTable.scopeByNode[node] else {
@@ -75,6 +79,7 @@ extension CompilerImpl {
                                     freeVariableNames: symbolNames.free,
                                     cellVariableNames: symbolNames.cell,
                                     argCount: argCount,
+                                    posOnlyArgCount: posOnlyArgCount,
                                     kwOnlyArgCount: kwOnlyArgCount,
                                     firstLine: node.start.line)
 

--- a/Sources/Objects/Generated/Py+TypeDefinitions.swift
+++ b/Sources/Objects/Generated/Py+TypeDefinitions.swift
@@ -1655,6 +1655,8 @@ extension Py {
       self.add(py, type: type, name: "co_firstlineno", property: co_firstlineno, doc: nil)
       let co_argcount = FunctionWrapper(name: "__get__", fn: PyCode.co_argcount(_:zelf:))
       self.add(py, type: type, name: "co_argcount", property: co_argcount, doc: nil)
+      let co_posonlyargcount = FunctionWrapper(name: "__get__", fn: PyCode.co_posonlyargcount(_:zelf:))
+      self.add(py, type: type, name: "co_posonlyargcount", property: co_posonlyargcount, doc: nil)
       let co_kwonlyargcount = FunctionWrapper(name: "__get__", fn: PyCode.co_kwonlyargcount(_:zelf:))
       self.add(py, type: type, name: "co_kwonlyargcount", property: co_kwonlyargcount, doc: nil)
       let co_nlocals = FunctionWrapper(name: "__get__", fn: PyCode.co_nlocals(_:zelf:))

--- a/Sources/Objects/Generated/Types+Generated.swift
+++ b/Sources/Objects/Generated/Types+Generated.swift
@@ -1299,6 +1299,7 @@ extension PyCode {
     zelf.cellVariableNamesPtr.deinitialize()
     zelf.freeVariableNamesPtr.deinitialize()
     zelf.argCountPtr.deinitialize()
+    zelf.posOnlyArgCountPtr.deinitialize()
     zelf.kwOnlyArgCountPtr.deinitialize()
     zelf.predictedObjectStackCountPtr.deinitialize()
 

--- a/Sources/Objects/Generated/Types+Generated.swift
+++ b/Sources/Objects/Generated/Types+Generated.swift
@@ -1163,6 +1163,7 @@ extension PyCode {
     internal let cellVariableNamesOffset: Int
     internal let freeVariableNamesOffset: Int
     internal let argCountOffset: Int
+    internal let posOnlyArgCountOffset: Int
     internal let kwOnlyArgCountOffset: Int
     internal let predictedObjectStackCountOffset: Int
     internal let size: Int
@@ -1188,12 +1189,13 @@ extension PyCode {
           GenericLayout.Field([MangledName].self), // PyCode.cellVariableNames
           GenericLayout.Field([MangledName].self), // PyCode.freeVariableNames
           GenericLayout.Field(Int.self), // PyCode.argCount
+          GenericLayout.Field(Int.self), // PyCode.posOnlyArgCount
           GenericLayout.Field(Int.self), // PyCode.kwOnlyArgCount
           GenericLayout.Field(Int.self) // PyCode.predictedObjectStackCount
         ]
       )
 
-      assert(layout.offsets.count == 16)
+      assert(layout.offsets.count == 17)
       self.codeObjectOffset = layout.offsets[0]
       self.nameOffset = layout.offsets[1]
       self.qualifiedNameOffset = layout.offsets[2]
@@ -1208,8 +1210,9 @@ extension PyCode {
       self.cellVariableNamesOffset = layout.offsets[11]
       self.freeVariableNamesOffset = layout.offsets[12]
       self.argCountOffset = layout.offsets[13]
-      self.kwOnlyArgCountOffset = layout.offsets[14]
-      self.predictedObjectStackCountOffset = layout.offsets[15]
+      self.posOnlyArgCountOffset = layout.offsets[14]
+      self.kwOnlyArgCountOffset = layout.offsets[15]
+      self.predictedObjectStackCountOffset = layout.offsets[16]
       self.size = layout.size
       self.alignment = layout.alignment
     }
@@ -1252,6 +1255,8 @@ extension PyCode {
   internal var freeVariableNamesPtr: Ptr<[MangledName]> { Ptr(self.ptr, offset: Self.layout.freeVariableNamesOffset) }
   /// Property: `PyCode.argCount`.
   internal var argCountPtr: Ptr<Int> { Ptr(self.ptr, offset: Self.layout.argCountOffset) }
+  /// Property: `PyCode.posOnlyArgCount`.
+  internal var posOnlyArgCountPtr: Ptr<Int> { Ptr(self.ptr, offset: Self.layout.posOnlyArgCountOffset) }
   /// Property: `PyCode.kwOnlyArgCount`.
   internal var kwOnlyArgCountPtr: Ptr<Int> { Ptr(self.ptr, offset: Self.layout.kwOnlyArgCountOffset) }
   /// Property: `PyCode.predictedObjectStackCount`.

--- a/Sources/Objects/Types - code/PyCode.swift
+++ b/Sources/Objects/Types - code/PyCode.swift
@@ -136,7 +136,7 @@ public struct PyCode: PyObjectMixin {
   /// - kwds argument name (i.e., **kwargs)
   /// - any other local variable names.
   ///
-  /// So you need to look at `argCount`, `kwOnlyArgCount` and `codeFlags`
+  /// So you need to look at `argCount`, `posOnlyArgCount`, `kwOnlyArgCount` and `codeFlags`
   /// to fully interpret this
   ///
   /// This value is taken directly from the SymbolTable.
@@ -189,6 +189,11 @@ public struct PyCode: PyObjectMixin {
   /// including those with default values (but excluding `*args`).
   /// CPython: `co_argcount`.
   public var argCount: Int { self.argCountPtr.pointee }
+
+  // sourcery: storedProperty
+  /// The number of positional only arguments the code object expects to receive,
+  /// CPython: `co_posonlyargcount`.
+  public var posOnlyArgCount: Int { self.posOnlyArgCountPtr.pointee }
 
   // sourcery: storedProperty
   /// The number of keyword arguments the code object can receive.
@@ -266,6 +271,7 @@ public struct PyCode: PyObjectMixin {
     self.freeVariableNamesPtr.initialize(to: code.freeVariableNames)
 
     self.argCountPtr.initialize(to: code.argCount)
+    self.posOnlyArgCountPtr.initialize(to: code.posOnlyArgCount)
     self.kwOnlyArgCountPtr.initialize(to: code.kwOnlyArgCount)
     self.predictedObjectStackCountPtr.initialize(to: 0)
 
@@ -487,6 +493,15 @@ public struct PyCode: PyObjectMixin {
     }
 
     return PyResult(py, zelf.argCount)
+  }
+
+  // sourcery: pyproperty = co_posonlyargcount
+  internal static func co_posonlyargcount(_ py: Py, zelf _zelf: PyObject) -> PyResult {
+    guard let zelf = Self.downcast(py, _zelf) else {
+      return Self.invalidZelfArgument(py, _zelf, "co_posonlyargcount")
+    }
+
+    return PyResult(py, zelf.posOnlyArgCount)
   }
 
   // sourcery: pyproperty = co_kwonlyargcount

--- a/Sources/Objects/Types - code/PyFrame+FastLocals.swift
+++ b/Sources/Objects/Types - code/PyFrame+FastLocals.swift
@@ -208,7 +208,7 @@ private struct FillFastLocals {
       return nil
     }
 
-    // Handle keyword arguments
+    // swiftlint:disable:next closure_body_length
     return self.py.forEach(dict: kwargs) { key, value in
       guard let keyword = self.py.cast.asString(key) else {
         let error = self.newTypeError("keywords must be strings")
@@ -224,7 +224,8 @@ private struct FillFastLocals {
         }
 
         guard index >= self.code.posOnlyArgCount else {
-          let error = self.newTypeError("got some positional-only arguments passed as keyword arguments: '\(keyword)'")
+          let msg = "got some positional-only arguments passed as keyword arguments: '\(keyword)'"
+          let error = self.newTypeError(msg)
           return .error(error)
         }
 

--- a/Sources/Objects/Types - code/PyFrame+FastLocals.swift
+++ b/Sources/Objects/Types - code/PyFrame+FastLocals.swift
@@ -223,6 +223,11 @@ private struct FillFastLocals {
           continue
         }
 
+        guard index >= self.code.posOnlyArgCount else {
+          let error = self.newTypeError("got some positional-only arguments passed as keyword arguments: '\(keyword)'")
+          return .error(error)
+        }
+
         guard !self.isSet(index: index) else {
           let error = self.newTypeError("got multiple values for argument '\(keyword)'")
           return .error(error)

--- a/Sources/Parser/Errors/ParserErrorKind.swift
+++ b/Sources/Parser/Errors/ParserErrorKind.swift
@@ -1,5 +1,6 @@
 import VioletLexer
 
+// swiftlint:disable line_length
 // cSpell:ignore nonbytes
 
 public enum ParserErrorKind: Equatable {

--- a/Sources/Parser/Errors/ParserErrorKind.swift
+++ b/Sources/Parser/Errors/ParserErrorKind.swift
@@ -12,6 +12,10 @@ public enum ParserErrorKind: Equatable {
   case duplicateVarargs
   /// Duplicate keyworded variable length argument (the one with '**').
   case duplicateKwargs
+  /// Positional only separator after variable length argument (the one with '*').
+  case posOnlyAfterVarargs
+  /// Positional only separator after keyworded variable length argument (the one with '**').
+  case posOnlyAfterKwargs
   /// Argument after keyworded variable length argument (the one with '**').
   case argsAfterKwargs
   /// Non-keyworded variable length argument (the one with '*') after
@@ -110,6 +114,10 @@ extension ParserErrorKind: CustomStringConvertible {
       return "Duplicate non-keyworded variable length argument (the one with '*')."
     case .duplicateKwargs:
       return "Duplicate keyworded variable length argument (the one with '**')."
+    case .posOnlyAfterVarargs:
+      return "Positional only separator after variable length argument (the one with '*')"
+    case .posOnlyAfterKwargs:
+      return "Positional only separator after keyworded variable length argument (the one with '**')"
     case .argsAfterKwargs:
       return "Argument after keyworded variable length argument (the one with '**')."
     case .varargsAfterKwargs:

--- a/Sources/Parser/Expressions/Parser+Arguments.swift
+++ b/Sources/Parser/Expressions/Parser+Arguments.swift
@@ -208,10 +208,10 @@ extension Parser {
   private func parsePosOnlySeparator(ir: inout ArgumentsIR) throws {
     assert(self.peek.kind == .slash)
     guard case .none = ir.vararg else {
-      throw self.error(.argsAfterKwargs)
+      throw self.error(.posOnlyAfterVarargs)
     }
     guard ir.kwarg == nil else {
-      throw self.error(.varargsAfterKwargs)
+      throw self.error(.posOnlyAfterKwargs)
     }
     ir.end = self.peek.end // slash end
     try self.advance() // /

--- a/Sources/Parser/Generated/AST.swift
+++ b/Sources/Parser/Generated/AST.swift
@@ -2734,6 +2734,8 @@ public struct Arguments: ASTNode, CustomStringConvertible {
   /// When a function is called, positional arguments are mapped
   /// to these parameters based solely on their position.
   public var args: [Argument]
+  /// Count of positional only arguments of 'args'
+  public var posOnlyArgCount: Int
   /// Default values for positional arguments.
   /// If there are fewer defaults, they correspond to the last *n* arguments.
   /// - Important: The default value is evaluated only **once**.
@@ -2767,6 +2769,7 @@ public struct Arguments: ASTNode, CustomStringConvertible {
   public init(
     id: ASTNodeId,
     args: [Argument],
+    posOnlyArgCount: Int,
     defaults: [Expression],
     vararg: Vararg,
     kwOnlyArgs: [Argument],
@@ -2777,6 +2780,7 @@ public struct Arguments: ASTNode, CustomStringConvertible {
   ) {
     self.id = id
     self.args = args
+    self.posOnlyArgCount = posOnlyArgCount
     self.defaults = defaults
     self.vararg = vararg
     self.kwOnlyArgs = kwOnlyArgs

--- a/Sources/Parser/Generated/AST.swift
+++ b/Sources/Parser/Generated/AST.swift
@@ -2734,7 +2734,7 @@ public struct Arguments: ASTNode, CustomStringConvertible {
   /// When a function is called, positional arguments are mapped
   /// to these parameters based solely on their position.
   public var args: [Argument]
-  /// Count of positional only arguments of 'args'
+  /// Count of positional-only arguments.
   public var posOnlyArgCount: Int
   /// Default values for positional arguments.
   /// If there are fewer defaults, they correspond to the last *n* arguments.

--- a/Sources/Parser/Generated/ASTBuilder.swift
+++ b/Sources/Parser/Generated/ASTBuilder.swift
@@ -1182,6 +1182,7 @@ public struct ASTBuilder {
 
   public mutating func arguments(
     args: [Argument],
+    posOnlyArgCount: Int,
     defaults: [Expression],
     vararg: Vararg,
     kwOnlyArgs: [Argument],
@@ -1193,6 +1194,7 @@ public struct ASTBuilder {
     return Arguments(
       id: self.getNextId(),
       args: args,
+      posOnlyArgCount: posOnlyArgCount,
       defaults: defaults,
       vararg: vararg,
       kwOnlyArgs: kwOnlyArgs,

--- a/Sources/Parser/Printer/ASTPrinter+Expr.swift
+++ b/Sources/Parser/Printer/ASTPrinter+Expr.swift
@@ -331,8 +331,6 @@ extension ASTPrinter {
       self.text("Args: none") :
       self.block(title: "Args", lines: node.args.map(self.visit))
 
-    let posOnlyArgCount = self.text("PosOnlyArgCount: \(node.posOnlyArgCount)")
-
     let defaults = node.defaults.isEmpty ?
       self.text("Defaults: none") :
       self.block(title: "Defaults", lines: node.defaults.map(self.visit))
@@ -361,7 +359,7 @@ extension ASTPrinter {
       title: "Arguments(start: \(node.start), end: \(node.end))",
       lines:
         args,
-        posOnlyArgCount,
+        self.text("PosOnlyArgCount: \(node.posOnlyArgCount)"),
         defaults,
         vararg,
         kwOnly,

--- a/Sources/Parser/Printer/ASTPrinter+Expr.swift
+++ b/Sources/Parser/Printer/ASTPrinter+Expr.swift
@@ -331,6 +331,8 @@ extension ASTPrinter {
       self.text("Args: none") :
       self.block(title: "Args", lines: node.args.map(self.visit))
 
+    let posOnlyArgCount = self.text("PosOnlyArgCount: \(node.posOnlyArgCount)")
+
     let defaults = node.defaults.isEmpty ?
       self.text("Defaults: none") :
       self.block(title: "Defaults", lines: node.defaults.map(self.visit))
@@ -359,6 +361,7 @@ extension ASTPrinter {
       title: "Arguments(start: \(node.start), end: \(node.end))",
       lines:
         args,
+        posOnlyArgCount,
         defaults,
         vararg,
         kwOnly,

--- a/Tests/BytecodeTests/CodeObjectDescriptionTests.swift
+++ b/Tests/BytecodeTests/CodeObjectDescriptionTests.swift
@@ -29,6 +29,7 @@ class CodeObjectDescriptionTests: XCTestCase {
       freeVariableNames: [anna],
       cellVariableNames: [kristoff],
       argCount: 2013, // Year
+      posOnlyArgCount: 1, // Series number
       kwOnlyArgCount: 102, // Duration (in minutes)
       firstLine: SourceLine(2) // Oscars: 'Animated Feature Film' and 'Music'
     )
@@ -44,6 +45,7 @@ class CodeObjectDescriptionTests: XCTestCase {
     Kind: Module
     Flags: [generator]
     Arg count: 2013
+    Positional only arg count: 1
     Keyword only arg count: 102
     First line: 2
 
@@ -62,6 +64,7 @@ class CodeObjectDescriptionTests: XCTestCase {
       freeVariableNames: [anna],
       cellVariableNames: [kristoff],
       argCount: 2018, // Year
+      posOnlyArgCount: 2, // Series number
       kwOnlyArgCount: 103, // Duration (in minutes)
       firstLine: SourceLine(1) // Oscar nominations: Music
     )
@@ -91,6 +94,7 @@ class CodeObjectDescriptionTests: XCTestCase {
     Kind: Module
     Flags: [generator]
     Arg count: 2018
+    Positional only arg count: 2
     Keyword only arg count: 103
     First line: 1
 

--- a/Tests/BytecodeTests/Globals/createBuilder.swift
+++ b/Tests/BytecodeTests/Globals/createBuilder.swift
@@ -11,6 +11,7 @@ func createBuilder(
   freeVariableNames: [MangledName] = [],
   cellVariableNames: [MangledName] = [],
   argCount: Int = 0,
+  posOnlyArgCount: Int = 0,
   kwOnlyArgCount: Int = 0,
   firstLine: SourceLine = SourceLocation.start.line
 ) -> CodeObjectBuilder {
@@ -23,6 +24,7 @@ func createBuilder(
                            freeVariableNames: freeVariableNames,
                            cellVariableNames: cellVariableNames,
                            argCount: argCount,
+                           posOnlyArgCount: posOnlyArgCount,
                            kwOnlyArgCount: kwOnlyArgCount,
                            firstLine: firstLine)
 }

--- a/Tests/CompilerTests/ASTCreator.swift
+++ b/Tests/CompilerTests/ASTCreator.swift
@@ -1152,6 +1152,7 @@ extension ASTCreator {
     return Arguments(
       id: self.id,
       args: args,
+      posOnlyArgCount: 0,
       defaults: defaults,
       vararg: vararg,
       kwOnlyArgs: kwOnlyArgs,

--- a/Tests/CompilerTests/ASTCreator.swift
+++ b/Tests/CompilerTests/ASTCreator.swift
@@ -1141,6 +1141,7 @@ extension ASTCreator {
 
   internal func arguments(
     args: [Argument] = [],
+    posOnlyArgCount: Int = 0,
     defaults: [Expression] = [],
     vararg: Vararg = .none,
     kwOnlyArgs: [Argument] = [],
@@ -1149,10 +1150,11 @@ extension ASTCreator {
     start: SourceLocation? = nil,
     end: SourceLocation? = nil
   ) -> Arguments {
+    assert(args.count >= posOnlyArgCount)
     return Arguments(
       id: self.id,
       args: args,
-      posOnlyArgCount: 0,
+      posOnlyArgCount: posOnlyArgCount,
       defaults: defaults,
       vararg: vararg,
       kwOnlyArgs: kwOnlyArgs,

--- a/Tests/CompilerTests/CodeObject+Extensions.swift
+++ b/Tests/CompilerTests/CodeObject+Extensions.swift
@@ -24,6 +24,7 @@ extension CodeObject {
                                     freeVariableNames: [],
                                     cellVariableNames: [],
                                     argCount: 0,
+                                    posOnlyArgCount: 0,
                                     kwOnlyArgCount: 0,
                                     firstLine: 0)
 

--- a/Tests/CompilerTests/Compile expr/CompileLambda.swift
+++ b/Tests/CompilerTests/Compile expr/CompileLambda.swift
@@ -335,6 +335,64 @@ class CompileLambda: CompileTestCase {
     )
   }
 
+  // MARK: - Positional only
+
+  /// lambda zucchini, /, tomato: ratatouille
+  ///
+  ///  0 LOAD_CONST               0 (<code object <lambda> at 0x1028b81e0, file "<dis>", line 1>)
+  ///  2 LOAD_CONST               1 ('<lambda>')
+  ///  4 MAKE_FUNCTION            0
+  ///  6 RETURN_VALUE
+  /// f <code object <lambda> at 0x1028b81e0, file "<dis>", line 1>:
+  ///  0 LOAD_GLOBAL              0 (ratatouille)
+  ///  2 RETURN_VALUE
+  func test_positionalOnly() {
+    let expr = self.lambdaExpr(
+      args: self.arguments(
+        args: [self.arg(name: "zucchini"), self.arg(name: "tomato")],
+        posOnlyArgCount: 1
+      ),
+      body: self.identifierExpr(value: "ratatouille")
+    )
+
+    guard let code = self.compile(expr: expr) else {
+      return
+    }
+
+    XCTAssertCodeObject(
+      code,
+      name: "<module>",
+      qualifiedName: "",
+      kind: .module,
+      flags: [],
+      instructions: [
+        .loadConst(codeObject: .any),
+        .loadConst(string: "<lambda>"),
+        .makeFunction(flags: []),
+        .return
+      ],
+      childCodeObjectCount: 1
+    )
+
+    guard let lambdaCode = code.getChildCodeObject(atIndex: 0) else {
+      return
+    }
+
+    XCTAssertCodeObject(
+      lambdaCode,
+      name: "<lambda>",
+      qualifiedName: "<lambda>",
+      kind: .lambda,
+      flags: [.nested, .newLocals, .optimized],
+      instructions: [
+        .loadGlobal(name: "ratatouille"),
+        .return
+      ],
+      argCount: 2,
+      posOnlyArgCount: 1
+    )
+  }
+
   // MARK: - Variadic
 
   /// lambda *zucchini: ratatouille

--- a/Tests/CompilerTests/CompileAsserts.swift
+++ b/Tests/CompilerTests/CompileAsserts.swift
@@ -8,7 +8,7 @@ import VioletCompiler
 
 // MARK: - Assert code object
 
-// swiftlint:disable:next function_parameter_count
+// swiftlint:disable:next function_parameter_count function_body_length
 func XCTAssertCodeObject(_ code: CodeObject,
                          name: String,
                          qualifiedName: String,
@@ -16,6 +16,7 @@ func XCTAssertCodeObject(_ code: CodeObject,
                          flags: CodeObject.Flags,
                          instructions: [Instruction.Filled],
                          argCount: Int = 0,
+                         posOnlyArgCount: Int = 0,
                          kwOnlyArgCount: Int = 0,
                          childCodeObjectCount: Int = 0,
                          file: StaticString = #file,
@@ -43,6 +44,11 @@ func XCTAssertCodeObject(_ code: CodeObject,
   XCTAssertEqual(code.argCount,
                  argCount,
                  "Arg count",
+                 file: file,
+                 line: line)
+  XCTAssertEqual(code.posOnlyArgCount,
+                 posOnlyArgCount,
+                 "Positional only arg count",
                  file: file,
                  line: line)
   XCTAssertEqual(code.kwOnlyArgCount,

--- a/Tests/ObjectsTests/Generated/InvalidSelfArgumentMessageTests.swift
+++ b/Tests/ObjectsTests/Generated/InvalidSelfArgumentMessageTests.swift
@@ -267,6 +267,7 @@ class InvalidSelfArgumentMessageTests: PyTestCase {
     self.assertInvalidSelfArgumentMessage(py, type: type, getter: "co_filename")
     self.assertInvalidSelfArgumentMessage(py, type: type, getter: "co_firstlineno")
     self.assertInvalidSelfArgumentMessage(py, type: type, getter: "co_argcount")
+    self.assertInvalidSelfArgumentMessage(py, type: type, getter: "co_posonlyargcount")
     self.assertInvalidSelfArgumentMessage(py, type: type, getter: "co_kwonlyargcount")
     self.assertInvalidSelfArgumentMessage(py, type: type, getter: "co_nlocals")
 

--- a/Tests/ObjectsTests/Types - code/PyFrameTestsMixin.swift
+++ b/Tests/ObjectsTests/Types - code/PyFrameTestsMixin.swift
@@ -43,6 +43,7 @@ extension PyFrameTestsMixin {
       freeVariableNames: [],
       cellVariableNames: [],
       argCount: 0,
+      posOnlyArgCount: 0,
       kwOnlyArgCount: 0,
       firstLine: 0
     )

--- a/Tests/ParserTests/Expressions/ParseLambda.swift
+++ b/Tests/ParserTests/Expressions/ParseLambda.swift
@@ -27,6 +27,7 @@ class ParseLambda: XCTestCase {
         Args
           Arguments(start: 8:8, end: 8:8)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -60,6 +61,7 @@ class ParseLambda: XCTestCase {
               Arg
                 Name: zucchini
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -93,6 +95,7 @@ class ParseLambda: XCTestCase {
               Arg
                 Name: zucchini
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults
               FloatExpr(context: Load, start: 10:10, end: 11:16)
                 Value: 1.0
@@ -131,6 +134,7 @@ class ParseLambda: XCTestCase {
               Arg
                 Name: tomato
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -169,6 +173,7 @@ class ParseLambda: XCTestCase {
               Arg
                 Name: tomato
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults
               FloatExpr(context: Load, start: 14:14, end: 15:20)
                 Value: 1.0
@@ -201,6 +206,47 @@ class ParseLambda: XCTestCase {
     }
   }
 
+  // MARK: - Positional only
+
+  /// lambda zucchini, /, tomato: "Ratatouille"
+  func test_positionalOnly() {
+    let parser = createExprParser(
+      createToken(.lambda,                 start: loc0, end: loc1),
+      createToken(.identifier("zucchini"), start: loc6, end: loc7),
+      createToken(.comma,                  start: loc8, end: loc9),
+      createToken(.slash,                  start: loc10, end: loc11),
+      createToken(.comma,                  start: loc12, end: loc13),
+      createToken(.identifier("tomato"),   start: loc14, end: loc15),
+      createToken(.colon,                  start: loc16, end: loc17),
+      createToken(.string("Ratatouille"),  start: loc18, end: loc19)
+    )
+
+    guard let ast = parse(parser) else { return }
+
+    XCTAssertAST(ast, """
+    ExpressionAST(start: 0:0, end: 19:24)
+      LambdaExpr(context: Load, start: 0:0, end: 19:24)
+        Args
+          Arguments(start: 6:6, end: 15:20)
+            Args
+              Arg
+                Name: zucchini
+                Annotation: none
+              Arg
+                Name: tomato
+                Annotation: none
+            PosOnlyArgCount: 1
+            Defaults: none
+            Vararg: none
+            KwOnlyArgs: none
+            KwOnlyDefaults: none
+            Kwarg: none
+        Body
+          StringExpr(context: Load, start: 18:18, end: 19:24)
+            String: 'Ratatouille'
+    """)
+  }
+
   // MARK: - Variadic
 
   /// lambda *zucchini: "Ratatouille"
@@ -221,6 +267,7 @@ class ParseLambda: XCTestCase {
         Args
           Arguments(start: 6:6, end: 9:14)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg
               Named
@@ -258,6 +305,7 @@ class ParseLambda: XCTestCase {
         Args
           Arguments(start: 6:6, end: 17:22)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg
               Named
@@ -298,6 +346,7 @@ class ParseLambda: XCTestCase {
         Args
           Arguments(start: 6:6, end: 13:18)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg
               Named
@@ -355,6 +404,7 @@ class ParseLambda: XCTestCase {
         Args
           Arguments(start: 6:6, end: 11:16)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: unnamed
             KwOnlyArgs
@@ -405,6 +455,7 @@ class ParseLambda: XCTestCase {
         Args
           Arguments(start: 6:6, end: 9:14)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -438,6 +489,7 @@ class ParseLambda: XCTestCase {
         Args
           Arguments(start: 6:6, end: 11:16)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -501,6 +553,7 @@ class ParseLambda: XCTestCase {
               Arg
                 Name: zucchini
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg
               Named

--- a/Tests/ParserTests/Statements/ParseAsync.swift
+++ b/Tests/ParserTests/Statements/ParseAsync.swift
@@ -28,6 +28,7 @@ class ParseAsync: XCTestCase {
         Args
           Arguments(start: 8:8, end: 8:8)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none

--- a/Tests/ParserTests/Statements/ParseDecorators.swift
+++ b/Tests/ParserTests/Statements/ParseDecorators.swift
@@ -315,6 +315,7 @@ class ParseDecorators: XCTestCase {
         Args
           Arguments(start: 12:12, end: 12:12)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -356,6 +357,7 @@ class ParseDecorators: XCTestCase {
         Args
           Arguments(start: 14:14, end: 14:14)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none

--- a/Tests/ParserTests/Statements/ParseFunctionDef.swift
+++ b/Tests/ParserTests/Statements/ParseFunctionDef.swift
@@ -31,6 +31,7 @@ class ParseFunctionDef: XCTestCase {
         Args
           Arguments(start: 6:6, end: 6:6)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -67,6 +68,7 @@ class ParseFunctionDef: XCTestCase {
         Args
           Arguments(start: 6:6, end: 6:6)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -109,6 +111,7 @@ class ParseFunctionDef: XCTestCase {
               Arg
                 Name: zucchini
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -151,6 +154,7 @@ class ParseFunctionDef: XCTestCase {
                 Annotation
                   IdentifierExpr(context: Load, start: 10:10, end: 11:16)
                     Value: Vegetable
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -191,6 +195,7 @@ class ParseFunctionDef: XCTestCase {
               Arg
                 Name: zucchini
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults
               FloatExpr(context: Load, start: 10:10, end: 11:16)
                 Value: 1.0
@@ -236,6 +241,7 @@ class ParseFunctionDef: XCTestCase {
               Arg
                 Name: tomato
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -281,6 +287,7 @@ class ParseFunctionDef: XCTestCase {
               Arg
                 Name: tomato
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults
               FloatExpr(context: Load, start: 14:14, end: 15:20)
                 Value: 1.0
@@ -319,6 +326,54 @@ class ParseFunctionDef: XCTestCase {
     }
   }
 
+  // MARK: - Positional only
+
+  /// def cook(zucchini, / , tomato): "Ratatouille"
+  func test_positionalOnly() {
+    let parser = createStmtParser(
+      createToken(.def,                    start: loc0, end: loc1),
+      createToken(.identifier("cook"),     start: loc2, end: loc3),
+      createToken(.leftParen,              start: loc4, end: loc5),
+      createToken(.identifier("zucchini"), start: loc6, end: loc7),
+      createToken(.comma,                  start: loc8, end: loc9),
+      createToken(.slash,                  start: loc10, end: loc11),
+      createToken(.comma,                  start: loc12, end: loc13),
+      createToken(.identifier("tomato"),   start: loc14, end: loc15),
+      createToken(.rightParen,             start: loc16, end: loc17),
+      createToken(.colon,                  start: loc18, end: loc19),
+      createToken(.string("Ratatouille"),  start: loc20, end: loc21)
+    )
+
+    guard let ast = parse(parser) else { return }
+
+    XCTAssertAST(ast, """
+    ModuleAST(start: 0:0, end: 21:26)
+      FunctionDefStmt(start: 0:0, end: 21:26)
+        Name: cook
+        Args
+          Arguments(start: 6:6, end: 15:20)
+            Args
+              Arg
+                Name: zucchini
+                Annotation: none
+              Arg
+                Name: tomato
+                Annotation: none
+            PosOnlyArgCount: 1
+            Defaults: none
+            Vararg: none
+            KwOnlyArgs: none
+            KwOnlyDefaults: none
+            Kwarg: none
+        Body
+          ExprStmt(start: 20:20, end: 21:26)
+            StringExpr(context: Load, start: 20:20, end: 21:26)
+              String: 'Ratatouille'
+        Decorators: none
+        Returns: none
+    """)
+  }
+
   // MARK: - Variadic
 
   /// def cook(*zucchini): "Ratatouille"
@@ -343,6 +398,7 @@ class ParseFunctionDef: XCTestCase {
         Args
           Arguments(start: 6:6, end: 9:14)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg
               Named
@@ -387,6 +443,7 @@ class ParseFunctionDef: XCTestCase {
         Args
           Arguments(start: 6:6, end: 17:22)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg
               Named
@@ -434,6 +491,7 @@ class ParseFunctionDef: XCTestCase {
         Args
           Arguments(start: 6:6, end: 13:18)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg
               Named
@@ -501,6 +559,7 @@ class ParseFunctionDef: XCTestCase {
         Args
           Arguments(start: 6:6, end: 11:16)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: unnamed
             KwOnlyArgs
@@ -561,6 +620,7 @@ class ParseFunctionDef: XCTestCase {
         Args
           Arguments(start: 6:6, end: 9:14)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -601,6 +661,7 @@ class ParseFunctionDef: XCTestCase {
         Args
           Arguments(start: 6:6, end: 11:16)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -674,6 +735,7 @@ class ParseFunctionDef: XCTestCase {
               Arg
                 Name: zucchini
                 Annotation: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg
               Named

--- a/Tests/ParserTests/Statements/ParseSuite.swift
+++ b/Tests/ParserTests/Statements/ParseSuite.swift
@@ -45,6 +45,7 @@ class ParseSuite: XCTestCase {
         Args
           Arguments(start: 6:6, end: 6:6)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none
@@ -94,6 +95,7 @@ class ParseSuite: XCTestCase {
             Args
               Arguments(start: 16:16, end: 16:16)
                 Args: none
+                PosOnlyArgCount: 0
                 Defaults: none
                 Vararg: none
                 KwOnlyArgs: none
@@ -141,6 +143,7 @@ class ParseSuite: XCTestCase {
         Args
           Arguments(start: 6:6, end: 6:6)
             Args: none
+            PosOnlyArgCount: 0
             Defaults: none
             Vararg: none
             KwOnlyArgs: none


### PR DESCRIPTION
https://peps.python.org/pep-0570/

I know Violet is targeting Python 3.7 for now, but this is required to catch up the upper version later.